### PR TITLE
Fix `PLAYER_CSACTION` shift

### DIFF
--- a/include/z64player.h
+++ b/include/z64player.h
@@ -790,7 +790,9 @@ typedef enum PlayerCsAction {
     /* 0x77 */ PLAYER_CSACTION_119,
     /* 0x78 */ PLAYER_CSACTION_120,
     /* 0x79 */ PLAYER_CSACTION_121,
+#if MM_VERSION >= N64_US
     /* 0x7A */ PLAYER_CSACTION_122,
+#endif
     /* 0x7B */ PLAYER_CSACTION_123,
     /* 0x7C */ PLAYER_CSACTION_124,
     /* 0x7D */ PLAYER_CSACTION_125,

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -12225,7 +12225,11 @@ s8 sPlayerCueToCsActionMap[PLAYER_CUEID_MAX] = {
     PLAYER_CSACTION_120,  // PLAYER_CUEID_88
     PLAYER_CSACTION_114,  // PLAYER_CUEID_89
     PLAYER_CSACTION_111,  // PLAYER_CUEID_90
+#if MM_VERSION >= N64_US
     PLAYER_CSACTION_122,  // PLAYER_CUEID_91
+#else
+    PLAYER_CSACTION_NONE,  // PLAYER_CUEID_91
+#endif
 };
 
 f32 D_8085D3E0[PLAYER_FORM_MAX] = {
@@ -20204,7 +20208,9 @@ PlayerCsActionEntry sPlayerCsActionInitFuncs[PLAYER_CSACTION_MAX] = {
     /* PLAYER_CSACTION_119 */ { PLAYER_CSTYPE_ANIM_7, { &gPlayerAnim_demo_suwari2 } },
     /* PLAYER_CSACTION_120 */ { PLAYER_CSTYPE_ANIM_7, { &gPlayerAnim_demo_suwari3 } },
     /* PLAYER_CSACTION_121 */ { PLAYER_CSTYPE_ACTION, { Player_CsAction_7 } },
+#if MM_VERSION >= N64_US
     /* PLAYER_CSACTION_122 */ { PLAYER_CSTYPE_NONE, { NULL } },
+#endif
     /* PLAYER_CSACTION_123 */ { PLAYER_CSTYPE_ACTION, { Player_CsAction_9 } },
     /* PLAYER_CSACTION_124 */ { PLAYER_CSTYPE_ANIM_7, { &gPlayerAnim_clink_demo_get1 } },
     /* PLAYER_CSACTION_125 */ { PLAYER_CSTYPE_ANIM_5, { &gPlayerAnim_clink_demo_get2 } },
@@ -20347,7 +20353,9 @@ PlayerCsActionEntry sPlayerCsActionUpdateFuncs[PLAYER_CSACTION_MAX] = {
     /* PLAYER_CSACTION_119 */ { PLAYER_CSTYPE_ANIM_11, { NULL } },
     /* PLAYER_CSACTION_120 */ { PLAYER_CSTYPE_ANIM_11, { NULL } },
     /* PLAYER_CSACTION_121 */ { PLAYER_CSTYPE_ACTION, { Player_CsAction_8 } },
+#if MM_VERSION >= N64_US
     /* PLAYER_CSACTION_122 */ { PLAYER_CSTYPE_ACTION, { Player_CsAction_12 } },
+#endif
     /* PLAYER_CSACTION_123 */ { PLAYER_CSTYPE_ACTION, { Player_CsAction_10 } },
     /* PLAYER_CSACTION_125 */ { PLAYER_CSTYPE_ANIM_11, { NULL } },
     /* PLAYER_CSACTION_124 */ { PLAYER_CSTYPE_ANIM_11, { NULL } },


### PR DESCRIPTION
The data for `sPlayerCsActionInitFuncs` and `sPlayerCsActionUpdateFuncs` tell us that `PLAYER_CSACTION_122` doesn't exist in JP 1.1. There's some weirdness going on in `sPlayerCueToCsActionMap` where we would *expect* some of the values to be shifted in JP, but they actually *aren't*, but I gave up on solving that for now. This is closer to the "correct" approach, and it should automatically fix functions that reference `PLAYER_CSACTION`s larger than 123.